### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -2,7 +2,9 @@
   "parallel": 4,
   "targetDefaults": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": [
+        "^build"
+      ],
       "cache": true
     },
     "test": {
@@ -12,12 +14,18 @@
       "cache": true
     },
     "lint-biome": {
-      "inputs": ["default", "{workspaceRoot}/biome.json"],
+      "inputs": [
+        "default",
+        "{workspaceRoot}/biome.json"
+      ],
       "cache": true
     }
   },
   "namedInputs": {
-    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "default": [
+      "{projectRoot}/**/*",
+      "sharedGlobals"
+    ],
     "production": [
       "default",
       "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
@@ -95,5 +103,6 @@
   "defaultBase": "next",
   "generatorOptions": {
     "preserveLocalDependencyProtocols": true
-  }
+  },
+  "nxCloudId": "68cbdb277b9b6be6c3d9a45b"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/68cbdb1ce34f9dedf10aa4cf/workspaces/68cbdb277b9b6be6c3d9a45b

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.